### PR TITLE
Statically link libstdc++ on linux

### DIFF
--- a/loc/CMakeLists.txt
+++ b/loc/CMakeLists.txt
@@ -24,6 +24,21 @@ add_executable (loc "loc.cpp" "include/loc.h"
     "include/FSLineCounter.h" "FSLineCounter.cpp")
 
 target_include_directories(loc PRIVATE ${Boost_INCLUDE_DIRS})
+
+# link libstdc++ statically on linux
+if (UNIX AND NOT APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc")
+    target_link_libraries(  loc 
+                            Boost::program_options 
+                            Boost::algorithm
+                            -static-stdlibc++
+                            -static-libgcc
+                            -pthread
+                            -ldl)
+else()
+    target_link_libraries(loc Boost::program_options Boost::algorithm)
+endif()
+
 target_link_libraries(loc Boost::program_options Boost::algorithm)
 
 if (CMAKE_VERSION VERSION_GREATER 3.12)


### PR DESCRIPTION
The Linux executable compiled by GitHub Actions didn't work on some Linux systems because they had an older version of ```libstdc++```. This will statically link to the ```libstdc++``` library so that the program won't have to use the system's version.