### PR TITLE
Project support

### DIFF
--- a/loc/CMakeLists.txt
+++ b/loc/CMakeLists.txt
@@ -8,7 +8,8 @@ if (CMAKE_VERSION VERSION_GREATER 3.30)
     cmake_policy(SET CMP0167 NEW)
 endif()
 
-find_package(Boost REQUIRED COMPONENTS program_options algorithm)
+find_package(Boost REQUIRED COMPONENTS algorithm)
+find_package(CLI11 CONFIG REQUIRED)
 
 # Add source to this project's executable.
 add_executable (loc "loc.cpp" "include/loc.h" 
@@ -19,7 +20,7 @@ add_executable (loc "loc.cpp" "include/loc.h"
     "include/FSLineCounter.h" "FSLineCounter.cpp" "include/ExpandGlob.h" "ExpandGlob.cpp")
 
 target_include_directories(loc PRIVATE ${Boost_INCLUDE_DIRS})
-target_link_libraries(loc PRIVATE Boost::program_options Boost::algorithm)
+target_link_libraries(loc PRIVATE Boost::algorithm CLI11::CLI11)
 
 if (CMAKE_VERSION VERSION_GREATER 3.12)
   set_property(TARGET loc PROPERTY CXX_STANDARD 20)

--- a/loc/Counter.cpp
+++ b/loc/Counter.cpp
@@ -12,9 +12,7 @@
 /**
  * Constructor for the Counter class.
  * @param jobs The number of threads to use.
- * @param extensions A string of all the file extensions to count, separated by semicolons.
- * @param paths A vector of paths to search for files. If a path is a directory, it is recursed.
- * @param ignores A string of all the paths to ignore, separated by semicolons.
+ * @param paths A vector of paths to search for files. Cannot include directories.
  * 
  * This constructor initializes the Counter object and starts the threads for counting. The
  * threads are started after the constructor is finished.
@@ -34,6 +32,24 @@ Counter::Counter(unsigned int jobs, const std::vector<std::string>& paths)
         file_queue.push(path);
     }
 }
+
+
+Counter::Counter(unsigned int jobs, std::string &directoryPath, std::vector<std::string>& extensions)
+{
+    this->jobs = jobs;
+
+    // Get the paths to all the files that match the specified pattern, excluding files that match any patterns in ignorePatterns
+    DirectoryScanner directorScanner{};
+    paths = directorScanner.Scan(directoryPath, extensions);
+
+    // put the files to be counted in the queue
+    for (const auto& path : this->paths)
+    {
+        std::scoped_lock<std::mutex> lock(file_queue_mutex);
+        file_queue.push(path);
+    }
+}
+
 
 /**
  * Count the lines of code in all the files in the queue.

--- a/loc/include/Counter.h
+++ b/loc/include/Counter.h
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <atomic>
 #include <filesystem>
+#include <fstream>
 
 #include "ILineCounter.h"
 
@@ -14,6 +15,8 @@ class Counter
 {
 public:
     Counter(unsigned int jobs, const std::vector<std::string>& paths);
+
+    Counter(unsigned int jobs, std::string& directoryPath, std::vector<std::string>& extensions);
 
     unsigned long Count();
 
@@ -39,7 +42,6 @@ private:
     bool isFileInDirectory(const std::filesystem::path& parentDir, const std::filesystem::path& filePath) const;
 
     void expandAllGlobsInPaths(std::vector<std::string>& paths);
-
 
     // multi-threading stuff
     std::queue<std::string> file_queue{};

--- a/loc/include/loc.h
+++ b/loc/include/loc.h
@@ -21,3 +21,10 @@ struct comma_numpunct : std::numpunct<char>
 protected: 
     std::string do_grouping() const override { return "\3"; } 
 };
+
+// Extensions for the different programming languages
+const std::vector<std::string> C_EXTENSIONS = { ".c", ".h" };
+const std::vector<std::string> CPP_EXTENSIONS = { ".cpp", ".h", ".hpp", ".cxx", ".hxx", ".c++", ".cc" };
+const std::vector<std::string> PY_EXTENSIONS = { ".py", ".pyw" };
+const std::vector<std::string> FS_EXTENSIONS = { ".fs", ".fsx" };
+const std::vector<std::string> CS_EXTENSIONS = { ".cs" };

--- a/loc/include/loc.h
+++ b/loc/include/loc.h
@@ -10,7 +10,7 @@
 #include <chrono>
 #include <locale>
 
-#include <boost/program_options.hpp>
+#include <CLI/CLI.hpp>
 
 #include "Counter.h"
 

--- a/loc/loc.cpp
+++ b/loc/loc.cpp
@@ -25,6 +25,23 @@ int main(int argc, char** argv)
 	files_command->add_option("paths", input_files, "List of paths to files to count")
 		->required()
 		->expected(1, -1);
+
+	
+	// directory command
+	auto directory_command = app.add_subcommand("dir", "Count lines of code in files matching a pattern in a directory");
+	string directory_path{};
+	string search_pattern{};
+	bool recursive = true;
+	bool gitignore = false;
+	directory_command->add_flag("-r,--recursive", recursive, "Search subdirectories")
+		->default_val(recursive);
+	directory_command->add_flag("-i,--gitignore", gitignore, "Ignore files found in .gitignore")
+		->default_val(gitignore);
+	directory_command->add_option("pattern", search_pattern, "Regex pattern to match filenames")
+		->required();
+	directory_command->add_option("directory", directory_path, "Directory to search")
+		->required()
+		->expected(1);
 	
 	// Parse the CLI arguments
 	CLI11_PARSE(app, argc, argv);
@@ -37,6 +54,10 @@ int main(int argc, char** argv)
 
 		// Print the lines of code
 		cout << "Counted " << lines << " lines of code";
+	}
+	else if (*directory_command)
+	{
+
 	}
 	else
 	{

--- a/loc/loc.cpp
+++ b/loc/loc.cpp
@@ -31,8 +31,29 @@ int main(int argc, char** argv)
 	auto directory_command = app.add_subcommand("dir", "Count lines of code in files with provided extensions in a directory");
 	string directory_path{};
 	vector<string> extensions{};
-	directory_command->add_option("-e,--extention", extensions, "Extensions of files to count")
-		->required();
+	bool cpp_extensions = false;
+	bool cs_extensions = false;
+	bool py_extensions = false;
+	bool fs_extensions = false;
+	bool c_extensions = false;
+
+	directory_command->add_flag("--cpp", cpp_extensions, "Use C++ extensions (.cpp, .h, .hpp, .cxx, .hxx, .c++, .cc)")
+		->capture_default_str()
+		->default_val(false);
+	directory_command->add_flag("--cs", cs_extensions, "Use C# extensions (.cs)")
+		->capture_default_str()
+		->default_val(false);
+	directory_command->add_flag("--py", py_extensions, "Use Python extensions (.py, .pyw)")
+		->capture_default_str()
+		->default_val(false);
+	directory_command->add_flag("--fs", fs_extensions, "Use F# extensions (.fs, .fsx)")
+		->capture_default_str()
+		->default_val(false);
+	directory_command->add_flag("--c", c_extensions, "Use C extensions (.c, .h)")
+		->capture_default_str()
+		->default_val(false);
+
+	directory_command->add_option("-e,--extention", extensions, "Extensions of files to count");
 	directory_command->add_option("directory", directory_path, "Directory to search")
 		->required()
 		->expected(1);
@@ -51,9 +72,26 @@ int main(int argc, char** argv)
 	}
 	else if (*directory_command)
 	{
+		if (cpp_extensions)
+			extensions.insert(extensions.end(), CPP_EXTENSIONS.begin(), CPP_EXTENSIONS.end());
+		if (cs_extensions)
+			extensions.insert(extensions.end(), CS_EXTENSIONS.begin(), CS_EXTENSIONS.end());
+		if (py_extensions)
+			extensions.insert(extensions.end(), PY_EXTENSIONS.begin(), PY_EXTENSIONS.end());
+		if (fs_extensions)
+			extensions.insert(extensions.end(), FS_EXTENSIONS.begin(), FS_EXTENSIONS.begin());
+		if (c_extensions)
+			extensions.insert(extensions.end(), C_EXTENSIONS.begin(), C_EXTENSIONS.end());
+
+		if (extensions.size() == 0)
+		{
+			cerr << "Error: No extensions specified\n";
+			return -1;
+		}
+
 		Counter counter(jobs, directory_path, extensions);
 		auto lines = counter.Count();
-
+		
 		cout << "Counted " << lines << " lines of code";
 	}
 	else

--- a/loc/loc.cpp
+++ b/loc/loc.cpp
@@ -28,16 +28,10 @@ int main(int argc, char** argv)
 
 	
 	// directory command
-	auto directory_command = app.add_subcommand("dir", "Count lines of code in files matching a pattern in a directory");
+	auto directory_command = app.add_subcommand("dir", "Count lines of code in files with provided extensions in a directory");
 	string directory_path{};
-	string search_pattern{};
-	bool recursive = true;
-	bool gitignore = false;
-	directory_command->add_flag("-r,--recursive", recursive, "Search subdirectories")
-		->default_val(recursive);
-	directory_command->add_flag("-i,--gitignore", gitignore, "Ignore files found in .gitignore")
-		->default_val(gitignore);
-	directory_command->add_option("pattern", search_pattern, "Regex pattern to match filenames")
+	vector<string> extensions{};
+	directory_command->add_option("-e,--extention", extensions, "Extensions of files to count")
 		->required();
 	directory_command->add_option("directory", directory_path, "Directory to search")
 		->required()
@@ -57,7 +51,10 @@ int main(int argc, char** argv)
 	}
 	else if (*directory_command)
 	{
+		Counter counter(jobs, directory_path, extensions);
+		auto lines = counter.Count();
 
+		cout << "Counted " << lines << " lines of code";
 	}
 	else
 	{

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,8 @@ programming project. It is written in C++ and designed to be very fast.
 - F#
 - Python
 
-Any C-style language should work, and the program uses 
-the C line counter for any file extension not recognized.
+Any language that uses C-style comments should work. If the program
+doesn't recognize a file extension, it uses the C line counter.
 
 ## Installation
 
@@ -78,7 +78,7 @@ cd ../../..
 
 ## Usage
 
-```loc [options] path1 path2 ...```
+```loc [options] subcommand```
 
 ### Options
 
@@ -86,7 +86,35 @@ cd ../../..
 
 ```-j [ --jobs ]``` - Number of threads to use. Default is number of CPU cores available
 
-```path``` - Path to file. Can be a wildcard pattern
+#### Subcommands:
+
+##### ```files```
+
+Count the lines of code in individual files
+
+Usage: ```loc [options] files [options] path1 path2 ...```
+
+##### ```dir```
+
+Count the lines of code in files with the specified
+extensions in a directory
+
+Usage: ```loc [options] dir [options] directory```
+
+Options:
+
+```--cpp``` Search for files with C++ extensions
+
+```--cs``` Search for files with C# extensions
+
+```--py``` Search for files with Python extensions
+
+```--fs``` Search for files with F# extensions
+
+  ```--c``` Search for files with C extensions
+
+  ```-e,--extention TEXT ...```  Other extensions to pass in.
+  For example: ```loc dir -e .cpp -e .h .```
 
 ### Example
 
@@ -94,7 +122,13 @@ To count the lines of code in the ```loc``` codebase from
 the toplevel directory running on 10 threads, use this command:
 
 ```
-loc -j 10 ./loc/*.cpp ./loc/include/*.h ./loc.tests/*.cpp
+loc -j 10 files ./loc/*.cpp ./loc/include/*.h ./loc.tests/*.cpp
+```
+
+Or use the directory command:
+
+```
+loc -j 10 dir --cpp .
 ```
 
 ## Speed

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "dependencies": [
-    "boost-program-options",
+    "boost-algorithm",
     "catch2",
-    "boost-algorithm"
+    "cli11"
   ]
 }


### PR DESCRIPTION
Support for counting the total lines of code in a project. Changing the CLI to use sub commands for counting individual files or a project. Changes the CLI parser from Boost Program Options to CLI11 (#7).