### PR TITLE
Trim both ends of line of code

### DIFF
--- a/loc/FileReader.cpp
+++ b/loc/FileReader.cpp
@@ -24,7 +24,7 @@ void FileReader::ReadFile(std::string path, std::vector<std::string>& output)
 	{
 		while (std::getline(file, line))
 		{
-			ltrim(line);
+			trim(line);
 			output.push_back(line);
 		}
 		file.close();
@@ -42,4 +42,19 @@ void FileReader::ltrim(std::string &s) {
             return std::isspace(ch);
         })
     );
+}
+
+void FileReader::rtrim(std::string& s) {
+	s.erase(
+		std::find_if_not(s.rbegin(), s.rend(), [](unsigned char ch) {
+			return std::isspace(ch);
+		}).base(),
+		s.end()
+	);
+}
+
+void FileReader::trim(std::string& s)
+{
+	ltrim(s);
+	rtrim(s);
 }

--- a/loc/include/FileReader.h
+++ b/loc/include/FileReader.h
@@ -10,4 +10,6 @@ public:
 	static void ReadFile(std::string path, std::vector<std::string>& output);
 private:
 	static void ltrim(std::string& s);
+	static void rtrim(std::string& s);
+	static void trim(std::string& s);
 };


### PR DESCRIPTION
The custom trim function only trimmed the leading whitespace from the string. It is now updated to trim both leading and trailing whitespace.