### PR TITLE
fix: Ignore files in `venv` and `node_modules`

### DIFF
--- a/loc/src/Counter.cpp
+++ b/loc/src/Counter.cpp
@@ -30,7 +30,7 @@ Counter::Counter(unsigned int jobs, const std::vector<std::filesystem::path>& di
 	std::vector<std::filesystem::path> ignore = ignoreDirs;
 	if (!includeGenerated)
 	{
-		std::vector<std::filesystem::path> generatedDirs{ "obj", "out", ".git", "bin" };
+		std::vector<std::filesystem::path> generatedDirs{ "obj", "out", ".git", "bin", "venv", "node_modules" };
 		ignore.insert(ignore.end(), generatedDirs.begin(), generatedDirs.end());
 	}
 


### PR DESCRIPTION
This adds `venv` and `node_modules` folders to the build directories list, so that files in them are automatically ignored when counting lines of code.